### PR TITLE
Moving requirements out of use cases. Rewording metadata text to be more coherent.

### DIFF
--- a/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
+++ b/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
@@ -765,7 +765,7 @@ is different from the threat of an interactive voice or video call. To
 mitigate traffic analysis, the sender might, for example, purposefully mis-mark
 metadata in some packets, add some randomness to avoid recurrent traffic patterns, etc.
 
-Requirements REQ-PRIVACY-ADDITIONAL and REQ-SIGNALING-AVOIDANCE are satisfied by
+REQ-PRIVACY-ADDITIONAL and REQ-SIGNALING-AVOIDANCE are satisfied by
 not revealing any information that could identify the application's identity, reason to signal,
 server identity and securing the metadata.
 
@@ -936,7 +936,7 @@ REQ-SIGNAL-EXPOSURE-FAIRNESS:
 considered. An example of such exposure is OS APIs.
 
 REQ-NETWORK-SEEKS-LOAD-DOWN:
-: During detected reactive event, the network must implement a
+: During detected reactive events, the network implements a
 reactive traffic policy to reduce or offload some of the traffic.
 : This may involve utilizing alternative network attachments
 available to the client (e.g., Wi-Fi).

--- a/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
+++ b/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
@@ -401,7 +401,7 @@ required to make use of the collaborative signaling:
 
 REQ-ISP-SCALE:
 : The metadata and other state information that a router has to
-maintain for each additional media flow it handles should be kept
+maintain for each additional flow it handles should be kept
 to a minimum or eliminated altogether.
 
 # Use Cases {#uc}
@@ -761,7 +761,7 @@ metadata in some packets, add some randomness to avoid recurrent traffic pattern
 
 REQ-PRIVACY-ADDITIONAL and REQ-SIGNALING-AVOIDANCE are satisfied by
 not revealing any information that could identify the application's identity, reason to signal,
-server identity and securing the metadata.
+server identity, and securing the metadata.
 
 # Non-Requirements {#non-req}
 
@@ -782,8 +782,8 @@ The principles outlined in {{?RFC8558}}, {{?RFC9049}} and {{?RFC9419}}
 contain security considerations and are referenced in {{metadata-req}}.
 
 Since the document focuses only on priorities within a flow
-(not specifying inter-flow priority), the entire requirement spec is not abusable by
-malicious traffic.
+(not specifying inter-flow priority), the document does not induce concerns related to a specific
+user or client declaring all flows or a subset of them as being more important. Such abuse concerns are thus not applicable.
 
 This document has no other security considerations.
 
@@ -1079,7 +1079,7 @@ Requirement: REQ-SCOPED-METADATA.
 
 ## Scalability {#scalability}
 
-There may be a large number of media flows handled by the server
+There may be a large number of flows handled by the server
 and wireless/access router. Per flow information (state) at a
 wireless router for optimizing the flow can negate the advantages
 offered as the number of flows handled increases.

--- a/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
+++ b/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
@@ -400,15 +400,9 @@ required to make use of the collaborative signaling:
   * Inspect client-to-server encrypted payload by network elements.
 
 REQ-ISP-SCALE:
-: The metadata and any other related state information that a network element (router) has to
-maintain for each additional flow it handles should be very low
-or none.
-
-REQ-CLIENT-VALIDATION:
-: The network needs to ensure the signal is coming from the same
-user/client that is part of the 5-tuple flow.  This is to ensure no
-other application influences the priority of another application's
-flow from within the same host.
+: The metadata and other state information that a router has to
+maintain for each additional media flow it handles should be kept
+to a minimum or eliminated altogether.
 
 # Use Cases {#uc}
 
@@ -604,7 +598,7 @@ Encrypting/Obfuscating metadata information is recommended ({{privacy}}).
 The client authorization signal provides the means to convey the key
 needed by the ISP to decrypt the metadata.
 
-REQ-CLIENT-DECIDES is satisfied by this in the client-to-network metadata
+REQ-CLIENT-DECIDES is satisfied by signaling Client Flow Authorization as part of client-to-network signal.
 
 ## Server-Network Metadata {#server-network}
 
@@ -679,7 +673,7 @@ of the flow.
 Per-packet priority or importance determines the drop priority of
 a packet.
 
-REQ-PACKET-PRIORITY is satisfied by this in the server-to-network metadata.
+REQ-PACKET-PRIORITY is satisfied by signaling Packet Priority as part of server-to-network metadata.
 
 ### Tolerance to Delay {#delay}
 
@@ -698,7 +692,7 @@ for the packets of the transport flow and may not necessarily reflect
 the exact delay tolerance values that allow an on-path observer to
 perform traffic analysis.
 
-REQ-PACKET-DELAY is satisfied by this in the server-to-network metadata.
+REQ-PACKET-DELAY is satisfied by signaling Tolerance to Delay as part of server-to-network metadata.
 
 # System Considerations {#sys-considerations}
 
@@ -769,33 +763,6 @@ REQ-PRIVACY-ADDITIONAL and REQ-SIGNALING-AVOIDANCE are satisfied by
 not revealing any information that could identify the application's identity, reason to signal,
 server identity and securing the metadata.
 
-## Scalability {#scalability}
-
-There may be a large number of media flows handled by the server
-and wireless/access router. Per flow information (state) at a
-wireless router for optimizing the flow can negate the advantages
-offered as the number of flows handled increases. The metadata and
-other state information that a router has to maintain for each
-additional media flow it handles should be kept to a minimum or
-eliminated altogether.
-
-REQ-ISP-SCALE is satisfied by this section.
-
-## Abuse and Constraints {#abuse}
-
-It is important that not every flow be prioritized; otherwise, the
-network devolves into the best-effort network that existed prior
-to metadata signaling. It is a requirement that mechanisms exist
-to prevent this occurrence.
-
-Such a mechanism might be simple, for example, a cellular network
-might allow one flow from a subscriber to declare itself as important;
-other flows with that subscriber are denied attempts to prioritize
-themselves. However, the network cannot identify whether the
-prioritized flow is legitimate or malicious.
-
-Such mechanism would satisfy REQ-CLIENT-VALIDATION.
-
 # Non-Requirements {#non-req}
 
 Application feedback with measurements of packets lost and delay
@@ -813,6 +780,10 @@ None.
 Security aspects for the metadata are discussed in {{privacy}}.
 The principles outlined in {{?RFC8558}}, {{?RFC9049}} and {{?RFC9419}}
 contain security considerations and are referenced in {{metadata-req}}.
+
+Since the document focuses only on priorities within a flow
+(not specifying inter-flow priority), the entire requirement spec is not abusable by
+malicious traffic.
 
 This document has no other security considerations.
 
@@ -944,9 +915,6 @@ available to the client (e.g., Wi-Fi).
 REQ-CONTINUITY:
 : Handover from one radio or router to another should continue to
 provide same service level.
-: The network must deploy wireless routers closer to users to reduce link
-latency while managing the increased frequency of handovers due to user
-movement and longer media sessions.
 
 REQ-MULTIPLE-BOTTLENECKS:
 : Signaling should support Multiple bottlenecks.
@@ -1040,7 +1008,7 @@ Use cases:
   client by informing the client of the network's bandwidth policy.
 
 
-# Extended Operational Considerations
+# Extended System Considerations
 
 ## Application Interference {#app-interference}
 
@@ -1108,3 +1076,12 @@ It is out of the scope of this document to discuss setups (e.g.,
 Rate (GBR) for specific flows is provided.
 
 Requirement: REQ-SCOPED-METADATA.
+
+## Scalability {#scalability}
+
+There may be a large number of media flows handled by the server
+and wireless/access router. Per flow information (state) at a
+wireless router for optimizing the flow can negate the advantages
+offered as the number of flows handled increases.
+
+Requirement: REQ-ISP-SCALE.

--- a/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
+++ b/draft-kwbdgrr-tsvwg-net-collab-rqmts.md
@@ -455,7 +455,7 @@ it limits the ability to maximize network utilization and use the transiently av
 Dropping or delaying of (media) packets randomly is likely to lower network utilization
 and application performance.
 
-    Requirement: REQ-PACKET-PRIORITY.
+    Requirement: REQ-PACKET-PRIORITY, REQ-PACKET-DELAY.
 
     Impact: By identifying packets that tolerate being dropped, congestion can be reduced leading
     to improved performance/quality of service.
@@ -485,7 +485,7 @@ call to have a seamless meeting experience.
 file copy operation. A user types in/interacts with a document/file after triggering a
 save file operation, while save operation is on-going.
 
-    Requirement: REQ-PACKET-PRIORITY.
+    Requirement: REQ-PACKET-PRIORITY, REQ-PACKET-DELAY.
 
     Impact: By prioritizing graphic updates/interactive traffic, user
     interactivity is improved with lesser jitter.
@@ -497,7 +497,7 @@ the other wants to prioritize audio and other wants to prioritize
 video of the speaker. Each user's varied preferences can be catered
 with same type of metadata originating from the server.
 
-    Requirement: REQ-PAYLOAD-CLIENT-DECIDES.
+    Requirement: REQ-PACKET-PRIORITY, REQ-PAYLOAD-CLIENT-DECIDES.
 
     Impact: With the above requirement met, each client/user preferences are
     prioritized accordingly while maintaining scalability on the server.
@@ -507,7 +507,7 @@ The traffic comprises of haptic, video, audio, graphics update and
 keystrokes. During such reactive event, some packets need to be
 deprioritized/dropped to maintain interactivity.
 
-    Requirement: REQ-PACKET-PRIORITY.
+    Requirement: REQ-PACKET-PRIORITY, REQ-PACKET-DELAY.
 
     Impact: By prioritizing high priority traffic, user's
     interactive experience is improved with lesser jitter.
@@ -604,6 +604,8 @@ Encrypting/Obfuscating metadata information is recommended ({{privacy}}).
 The client authorization signal provides the means to convey the key
 needed by the ISP to decrypt the metadata.
 
+REQ-CLIENT-DECIDES is satisfied by this in the client-to-network metadata
+
 ## Server-Network Metadata {#server-network}
 
 Application flows (UDP 4-tuple) for live media, eXtended Reality
@@ -677,7 +679,7 @@ of the flow.
 Per-packet priority or importance determines the drop priority of
 a packet.
 
-Requirement: REQ-PACKET-PRIORITY.
+REQ-PACKET-PRIORITY is satisfied by this in the server-to-network metadata.
 
 ### Tolerance to Delay {#delay}
 
@@ -696,7 +698,7 @@ for the packets of the transport flow and may not necessarily reflect
 the exact delay tolerance values that allow an on-path observer to
 perform traffic analysis.
 
-Requirement: REQ-PACKET-DELAY.
+REQ-PACKET-DELAY is satisfied by this in the server-to-network metadata.
 
 # System Considerations {#sys-considerations}
 
@@ -763,7 +765,9 @@ is different from the threat of an interactive voice or video call. To
 mitigate traffic analysis, the sender might, for example, purposefully mis-mark
 metadata in some packets, add some randomness to avoid recurrent traffic patterns, etc.
 
-Requirements: REQ-PRIVACY-ADDITIONAL, REQ-SIGNALING-AVOIDANCE
+Requirements REQ-PRIVACY-ADDITIONAL and REQ-SIGNALING-AVOIDANCE are satisfied by
+not revealing any information that could identify the application's identity, reason to signal,
+server identity and securing the metadata.
 
 ## Scalability {#scalability}
 
@@ -775,7 +779,7 @@ other state information that a router has to maintain for each
 additional media flow it handles should be kept to a minimum or
 eliminated altogether.
 
-Requirement: REQ-ISP-SCALE.
+REQ-ISP-SCALE is satisfied by this section.
 
 ## Abuse and Constraints {#abuse}
 
@@ -790,7 +794,7 @@ other flows with that subscriber are denied attempts to prioritize
 themselves. However, the network cannot identify whether the
 prioritized flow is legitimate or malicious.
 
-Requirements: REQ-CLIENT-VALIDATION.
+Such mechanism would satisfy REQ-CLIENT-VALIDATION.
 
 # Non-Requirements {#non-req}
 
@@ -931,29 +935,37 @@ REQ-SIGNAL-EXPOSURE-FAIRNESS:
 : Means to expose the signal independent of the application should be
 considered. An example of such exposure is OS APIs.
 
+REQ-NETWORK-SEEKS-LOAD-DOWN:
+: During detected reactive event, the network must implement a
+reactive traffic policy to reduce or offload some of the traffic.
+: This may involve utilizing alternative network attachments
+available to the client (e.g., Wi-Fi).
+
 REQ-CONTINUITY:
 : Handover from one radio or router to another should continue to
 provide same service level.
+: The network must deploy wireless routers closer to users to reduce link
+latency while managing the increased frequency of handovers due to user
+movement and longer media sessions.
 
 REQ-MULTIPLE-BOTTLENECKS:
 : Signaling should support Multiple bottlenecks.
+: The network must identify multiple bottlenecks, including those
+within the ISP and subscriber networks, ensuring all bottlenecks
+benefit from network/client collaboration to enhance overall performance.
 
 REQ-SCOPED-METADATA:
 : Means to characterize the scope of a shared metadata for the sake of
 better interoperability should be supported.
+: The metadata can be used by the network to prioritize traffic
+within a single 5-tuple connection and metadata cannot be leveraged
+for prioritization between different flows.
+
+REQ-SINGLE-CHANNEL:
+: The network should use a single channel for sharing metadata
+to simplify the process and avoid the need for redundant functions.
 
 # Extended Use-Cases
-
-Requirements:
-
-REQ-MEDIA-AV-SEPARATE:
-: Audio can be prioritized differently than video. This is a per-flow
-metadata requirement.
-
-REQ-MEDIA-KEYFRAME:
-: Video contains partial frames and full frames, which need to be
-distinguished so that full frames can be indicated to the
-network. This is a per-packet metadata requirement.
 
 ## Media Streaming Extended
 
@@ -988,7 +1000,9 @@ available to the client (e.g., Wi-Fi).
 
 Network-to-client signals are useful to put in place adequate traffic
 distribution policies on the client (e.g., prefer the use of alternate
-paths, offload a network) (REQ-NETWORK-SEEKS-LOAD-DOWN).
+paths, offload a network).
+
+Requirement: REQ-NETWORK-SEEKS-LOAD-DOWN.
 
 ## Network Bandwidth & Network Rate Limiting Policies {#nrlp}
 
@@ -1059,10 +1073,7 @@ Requirement:  REQ-SINGLE-CHANNEL is preferred.
 
 ## Session Continuity {#continuity}
 
-The general trend in wireless networks is to deploy the wireless
-router closer to the user. This can help with low link latency but
-can result in more frequent handovers as the user moves between
-routers. The frequency of handovers increases when a user moves
+The frequency of handovers increases when a user moves
 faster or when the media session lasts longer. During handovers,
 there should be minimal delay incurred during handover in
 configuring/setting up the metadata of a media session in progress.
@@ -1088,13 +1099,9 @@ network has a visibility about the overall network attachment (e.g.
 inbound/outbound bandwidth discussed in
 {{?I-D.ietf-opsawg-teas-attachment-circuit}}).
 
-As such, hints about resource-like metadata is bound by default to
+Hints about resource-like metadata is bound by default to
 the overall network attachment, not specific to a given application
 or flow.
-
-Most importantly, the metadata can be used by the network to
-prioritize traffic within a single 5-tuple connection and metadata
-cannot be leveraged for prioritization between different flows.
 
 It is out of the scope of this document to discuss setups (e.g.,
 3GPP PDU Sessions) where network attachments with Guaranteed Bit


### PR DESCRIPTION
Requirements in metadata doesn't make sense since signaling the metadata satisfies the requirement.